### PR TITLE
Update test-pastry.cson

### DIFF
--- a/keymaps/test-pastry.cson
+++ b/keymaps/test-pastry.cson
@@ -1,6 +1,6 @@
-'.platform-darwin .editor':
+'.platform-darwin .atom-text-editor':
   'cmd-u': 'text-pastry:undo-last-selection'
-'.platform-linux .editor':
+'.platform-linux .atom-text-editor':
   'ctrl-u': 'text-pastry:undo-last-selection'
-'.platform-win32 .editor':
+'.platform-win32 .atom-text-editor':
    'ctrl-u': 'text-pastry:undo-last-selection'


### PR DESCRIPTION
The latest version of Atom gives a warning about using the deprecated `editor` selector. This fixes that.